### PR TITLE
update for dolfin-adjoint and libadjoint version 2016.1

### DIFF
--- a/pkgs/dolfin-adjoint.yaml
+++ b/pkgs/dolfin-adjoint.yaml
@@ -4,8 +4,8 @@ dependencies:
   run: [dolfin, ffc, fiat, instant, libadjoint, numpy, scipy, ufl]
 
 sources:
-- key: tar.gz:6jw62mw6yaevobxwnm5zphguxgrnqhzz
-  url: https://bitbucket.org/dolfin-adjoint/dolfin-adjoint/get/dolfin-adjoint-1.5.tar.gz
+- key: tar.gz:cvf5yxlscx6dkecem2x4bt6q3lrli6uh
+  url: https://bitbucket.org/dolfin-adjoint/dolfin-adjoint/get/dolfin-adjoint-2016.1.0.tar.gz
 
 when_build_dependency:
 - prepend_path: PATH

--- a/pkgs/libadjoint.yaml
+++ b/pkgs/libadjoint.yaml
@@ -3,8 +3,8 @@ dependencies:
   build: [gccxml, mpi, petsc, slepc, {{build_with}}]
 
 sources:
-- key: tar.gz:pvs4t2nxqssi6mwagvg5oqqhryhhj7ft
-  url: https://bitbucket.org/dolfin-adjoint/libadjoint/get/libadjoint-1.5.tar.gz
+- key: tar.gz:hxzxqmsuietvrslbw2zouptnci4wmr4i
+  url: https://bitbucket.org/dolfin-adjoint/libadjoint/get/libadjoint-2016.1.0.tar.gz
 
 defaults:
   # lib/python2.7/site-packages/libadjoint/clibadjoint.py contains hard-coded path


### PR DESCRIPTION
New keys and urls. 

Allows dolfin-adjoint and libadjoint to be included in the hashdist profile for the fenics-install script.