### PR TITLE
update for fenicstools and python-netcdf4

### DIFF
--- a/pkgs/fenicstools.yaml
+++ b/pkgs/fenicstools.yaml
@@ -4,5 +4,5 @@ dependencies:
   run: [mpi4py, numpy, h5py, python-netcdf4, pyvtk]
 
 sources:
-- key: git:cca3ed1cc39215636ebd3e2449dae44d5bb5781a
-  url: https://github.com/mikaem/fenicstools.git
+- key: tar.gz:fzg2ocja7bs5msashkays4wmqe5epalf
+  url: https://github.com/mikaem/fenicstools/archive/2016.1.tar.gz

--- a/pkgs/python-netcdf4.yaml
+++ b/pkgs/python-netcdf4.yaml
@@ -4,8 +4,8 @@ dependencies:
   run: [netcdf4, numpy]
 
 sources:
-  - url: http://netcdf4-python.googlecode.com/files/netCDF4-1.0.4.tar.gz
-    key: tar.gz:th26v25of6xje5m5co3zbxpeejvsxded
+  - url: https://github.com/Unidata/netcdf4-python/archive/v1.2.4rel.tar.gz
+    key: tar.gz:6o4bwxm7ekc62jzpoltywfzryiiq7ggl
 
 build_stages:
 - name: set_mpi_wrapper


### PR DESCRIPTION
New keys and urls.

Allows the latest fenicstools package, compatible with FEniCS version 2016.1, to be added to a fenics profile and installed.

The python-netcdf4 repository has moved to GitHub.